### PR TITLE
Adopts space-separated format for torrent paths

### DIFF
--- a/RED_PATH_SPEC.md
+++ b/RED_PATH_SPEC.md
@@ -39,16 +39,16 @@ Produce torrent-internal paths (`<folder>/<file>`) that **always**:
 ### Folder (destination directory leaf)
 
 ```bash
-<title> - <vol_XX> [- <subtitle>] [(year)] [(author)] {ASIN.xxxxx}
+<title> <vol_XX> [<subtitle>] [(year)] [(author)] {ASIN.xxxxx}
 ```
 
 ### File (destination filename)
 
 ```bash
-<title> - <vol_XX> [- <subtitle>] [(year)] [(author)] {ASIN.xxxxx} [H2OKing]<ext>
+<title> <vol_XX> [<subtitle>] [(year)] [(author)] {ASIN.xxxxx} [H2OKing]<ext>
 ```
 
-* Hyphens (`" - "`) join **title / volume / subtitle**.
+* Spaces separate **title / volume / subtitle**.
 * Space-separated tail holds `(year) (author) {ASIN} [tag]`.
 * Tag is optional and **last**.
 
@@ -132,17 +132,17 @@ Edge-safe notes:
 **Input (non-compliant):**
 
 ```bash
-Overlord - vol_13 - The Paladin of the Sacred Kingdom Part 2 (2024) (Kugane Maruyama) {ASIN.B0CW3NF5NY}/Overlord - vol_13 - The Paladin of the Sacred Kingdom Part 2 (2024) (Kugane Maruyama) {ASIN.B0CW3NF5NY}.m4b
+Overlord vol_13 The Paladin of the Sacred Kingdom Part 2 (2024) (Kugane Maruyama) {ASIN.B0CW3NF5NY}/Overlord vol_13 The Paladin of the Sacred Kingdom Part 2 (2024) (Kugane Maruyama) {ASIN.B0CW3NF5NY}.m4b
 ```
 
 **Trim path to compliant:**
 
 * Filename trims `(year)`, `(author)`, and `subtitle` →
-  `Overlord - vol_13 {ASIN.B0CW3NF5NY}.m4b`
+  `Overlord vol_13 {ASIN.B0CW3NF5NY}.m4b`
 * Folder remains full or trims down as needed. A fully compliant example you provided:
 
   ```bash
-  Overlord - vol_13 - The Paladin of the Sacred Kingdom Part 2 (2024) (Kugane Maruyama) {ASIN.B0CW3NF5NY}/Overlord - vol_13 {ASIN.B0CW3NF5NY}.m4b
+  Overlord vol_13 The Paladin of the Sacred Kingdom Part 2 (2024) (Kugane Maruyama) {ASIN.B0CW3NF5NY}/Overlord vol_13 {ASIN.B0CW3NF5NY}.m4b
   ```
 
   **Length:** 143 (compliant under 180).
@@ -150,7 +150,7 @@ Overlord - vol_13 - The Paladin of the Sacred Kingdom Part 2 (2024) (Kugane Maru
 ### 2) With a tag
 
 * If space allows:
-  `Title - vol_05 - Subtitle (2021) (Author) {ASIN.B0XXXXX} [H2OKing].m4b`
+  `Title vol_05 Subtitle (2021) (Author) {ASIN.B0XXXXX} [H2OKing].m4b`
 * If trimming needed, tag drops **before** subtitle drops in the file (per priority).
 
 ### 3) Minimal viable (very long titles)
@@ -191,7 +191,7 @@ def test_minimal_invariants():
     assert f.endswith(".m4b")
 
 def test_overlord_trimming():
-    src = Path("/src/Overlord - vol_13 - The Paladin of the Sacred Kingdom Part 2 (2024) (Kugane Maruyama) {ASIN.B0CW3NF5NY}")
+    src = Path("/src/Overlord vol_13 The Paladin of the Sacred Kingdom Part 2 (2024) (Kugane Maruyama) {ASIN.B0CW3NF5NY}")
     dst_root = Path("/dst")
     dst_dir, dst_file = build_dst_paths(src, dst_root, ".m4b")
     folder, file = dst_dir.name, dst_file.name
@@ -202,7 +202,7 @@ def test_overlord_trimming():
     assert "vol_" in file
 
 def test_trailing_paren_safety():
-    tricky = "Title (2020) In Name - vol_02 - (Tricky) Sub (2024) (Real Author) {ASIN.B0XYZ}"
+    tricky = "Title (2020) In Name vol_02 (Tricky) Sub (2024) (Real Author) {ASIN.B0XYZ}"
     t = parse_tokens(tricky, ".m4b")
     # inner parens preserved in title/subtitle; trailing tokens extracted
     assert t.year == "(2024)"
@@ -212,14 +212,14 @@ def test_trailing_paren_safety():
 
 def test_hyphen_preservation():
     """Test that series parts use hyphens, not spaces"""
-    name = "Test Series - vol_05 - Long Subtitle (2023) (Author) {ASIN.B0TEST}"
+    name = "Test Series vol_05 Long Subtitle (2023) (Author) {ASIN.B0TEST}"
     t = parse_tokens(name, ".m4b")
     filename = build_filename(t)
     folder = build_folder_name(t)
 
-    # Both should have "Test Series - vol_05 - Long Subtitle" at the start
-    assert filename.startswith("Test Series - vol_05 - Long Subtitle")
-    assert folder.startswith("Test Series - vol_05 - Long Subtitle")
+    # Both should have "Test Series vol_05 Long Subtitle" at the start
+    assert filename.startswith("Test Series vol_05 Long Subtitle")
+    assert folder.startswith("Test Series vol_05 Long Subtitle")
 
 def test_deterministic_extension():
     """Test that extension selection follows deterministic priority"""
@@ -271,7 +271,7 @@ def test_volume_normalization():
 def test_path_cap_enforcement():
     """Test that paths never exceed the cap"""
     # Create a very long name that would exceed 180 chars
-    long_name = f"{'Very ' * 20}Long Title - vol_01 - {'Super ' * 10}Long Subtitle (2024) (Very Long Author Name) {{ASIN.B0VERYLONGASIN}}"
+    long_name = f"{'Very ' * 20}Long Title vol_01 {'Super ' * 10}Long Subtitle (2024) (Very Long Author Name) {{ASIN.B0VERYLONGASIN}}"
 
     src = Path(f"/src/{long_name}")
     dst_root = Path("/dst")
@@ -416,11 +416,11 @@ Emit one line per processed source for operational visibility:
 ```json
 {
   "timestamp": "2025-09-15T00:00:00Z",
-  "src_path": "/mnt/user/audiobooks/Overlord - vol_13 - The Paladin of the Sacred Kingdom Part 2 (2024) (Kugane Maruyama) {ASIN.B0CW3NF5NY}",
-  "src_name": "Overlord - vol_13 - The Paladin of the Sacred Kingdom Part 2 (2024) (Kugane Maruyama) {ASIN.B0CW3NF5NY}",
-  "dst_folder": "Overlord - vol_13 - The Paladin of the Sacred Kingdom Part 2 (2024) (Kugane Maruyama) {ASIN.B0CW3NF5NY}",
-  "dst_file": "Overlord - vol_13 {ASIN.B0CW3NF5NY}.m4b",
-  "torrent_path": "Overlord - vol_13 - The Paladin of the Sacred Kingdom Part 2 (2024) (Kugane Maruyama) {ASIN.B0CW3NF5NY}/Overlord - vol_13 {ASIN.B0CW3NF5NY}.m4b",
+  "src_path": "/mnt/user/audiobooks/Overlord vol_13 The Paladin of the Sacred Kingdom Part 2 (2024) (Kugane Maruyama) {ASIN.B0CW3NF5NY}",
+  "src_name": "Overlord vol_13 The Paladin of the Sacred Kingdom Part 2 (2024) (Kugane Maruyama) {ASIN.B0CW3NF5NY}",
+  "dst_folder": "Overlord vol_13 The Paladin of the Sacred Kingdom Part 2 (2024) (Kugane Maruyama) {ASIN.B0CW3NF5NY}",
+  "dst_file": "Overlord vol_13 {ASIN.B0CW3NF5NY}.m4b",
+  "torrent_path": "Overlord vol_13 The Paladin of the Sacred Kingdom Part 2 (2024) (Kugane Maruyama) {ASIN.B0CW3NF5NY}/Overlord vol_13 {ASIN.B0CW3NF5NY}.m4b",
   "length": 143,
   "cap": 180,
   "trim_steps": ["filename: drop year", "filename: drop author", "filename: drop subtitle"],

--- a/hardbound/red_paths.py
+++ b/hardbound/red_paths.py
@@ -99,27 +99,44 @@ def parse_tokens(name: str, extension: str = ".m4b") -> Tokens:
     if year_match:
         working = working[: year_match.start()].rstrip()
 
-    # Split remaining into parts by " - "
-    parts = [p.strip() for p in working.split(" - ") if p.strip()]
+    # Parse the new format: <title> vol_XX <subtitle>
+    # Look for volume pattern in the working string
+    vol_pattern = r"\b(vol_\d+)\b"
+    vol_match = re.search(vol_pattern, working, re.IGNORECASE)
 
-    if len(parts) < 2:
-        # Fallback: assume first part is title, try to find volume
-        title_part = parts[0] if parts else working
-        vol_match = re.search(r"vol_?\s*\d+", title_part, re.IGNORECASE)
-        if vol_match:
-            volume = normalize_volume(vol_match.group(0))
-            title = title_part.replace(vol_match.group(0), "").strip(" -")
-            subtitle = None
+    if vol_match:
+        volume_str = vol_match.group(1)
+        volume = normalize_volume(volume_str)
+
+        # Split around the volume to get title and subtitle
+        vol_start, vol_end = vol_match.span()
+        title_part = working[:vol_start].strip()
+        subtitle_part = working[vol_end:].strip()
+
+        # Clean up old format markers if present
+        # Remove trailing " -" from title and leading "- " from subtitle
+        if title_part.endswith(" -"):
+            title_part = title_part[:-2].strip()
+        if subtitle_part.startswith("- "):
+            subtitle_part = subtitle_part[2:].strip()
+
+        title = title_part
+        subtitle = subtitle_part if subtitle_part else None
+    else:
+        # Fallback: no volume found, try old format or default
+        parts = [p.strip() for p in working.split(" - ") if p.strip()]
+
+        if len(parts) >= 2:
+            # Try old format: title - vol_XX - subtitle
+            title = parts[0]
+            volume_part = parts[1]
+            volume = normalize_volume(volume_part)
+            subtitle = " - ".join(parts[2:]) if len(parts) > 2 else None
         else:
-            title = title_part
+            # Last resort: assume first part is title, default volume
+            title = parts[0] if parts else working
             volume = "vol_01"  # Default
             subtitle = None
-    else:
-        # Standard format: title - vol_XX - subtitle
-        title = parts[0]
-        volume_part = parts[1]
-        volume = normalize_volume(volume_part)
-        subtitle = " - ".join(parts[2:]) if len(parts) > 2 else None
 
     return Tokens(
         title=title.strip(),
@@ -135,13 +152,13 @@ def parse_tokens(name: str, extension: str = ".m4b") -> Tokens:
 
 def _series_str(tokens: Tokens, include_subtitle: bool = True) -> str:
     """
-    Build the left-hand 'series' part using hyphen joiners:
-    <title> - <vol_00> [- <subtitle>]
+    Build the left-hand 'series' part using space joiners:
+    <title> <vol_00> [<subtitle>]
     """
     parts = [tokens.title, tokens.volume]
     if include_subtitle and tokens.subtitle:
         parts.append(tokens.subtitle)
-    return " - ".join(parts)
+    return " ".join(parts)
 
 
 def build_filename(


### PR DESCRIPTION
Updates specification to use spaces instead of hyphens for joining title, volume, and subtitle in folder and file names. This improves parsing simplicity and maintains compliance with path length limits while preserving key metadata in trimmed versions.